### PR TITLE
Configure plugins

### DIFF
--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -31,9 +31,9 @@ echo "4. Running tests \`pytest\`"
 pytest
 echo
 
-# TODO: increase required coverate to al least 90
+# TODO: increase required coverate to al least 80
 echo "5. Running coverage \`pytest-cov\`"
-pytest --cov src --cov-fail-under 35
+pytest --cov src --cov-fail-under 50
 echo
 
 # SPDX-License-Identifier:

--- a/src/docthing/__main__.py
+++ b/src/docthing/__main__.py
@@ -105,12 +105,14 @@ def main():
     interpreter_manager = PluginManager(
         'meta-interpreter', [PlantUMLInterpreter({}), MarkdownNAVInterpreter({})])
     interpreter_manager.enable_plugins(
-        config['main']['meta'] if 'meta' in config['main'] else [])
+        config['main']['meta'] if 'meta' in config['main'] else [],
+        configs=config.get('meta', {}))
 
     # Initialize the plugin manager for Exporters
     exporter_manager = PluginManager(
         'exporter', [MarkdownExporter({})])
-    exporter_manager.enable_plugins(config['output']['type'])
+    exporter_manager.enable_plugins(config['output']['type'],
+                                    configs=config.get('type', {}))
 
     # Process the index file and generate the documentation
     blob = DocumentationBlob(

--- a/src/docthing/__main__.py
+++ b/src/docthing/__main__.py
@@ -103,14 +103,14 @@ def main():
 
     # Initialize the plugin manager for MetaInterpreters
     interpreter_manager = PluginManager(
-        'meta-interpreter', [PlantUMLInterpreter({}), MarkdownNAVInterpreter({})])
+        'meta-interpreter', [PlantUMLInterpreter(), MarkdownNAVInterpreter()])
     interpreter_manager.enable_plugins(
         config['main']['meta'] if 'meta' in config['main'] else [],
         configs=config.get('meta', {}))
 
     # Initialize the plugin manager for Exporters
     exporter_manager = PluginManager(
-        'exporter', [MarkdownExporter({})])
+        'exporter', [MarkdownExporter()])
     exporter_manager.enable_plugins(config['output']['type'],
                                     configs=config.get('type', {}))
 

--- a/src/docthing/config.py
+++ b/src/docthing/config.py
@@ -175,7 +175,7 @@ END FILE DOCUMENTATION '''
 
 import os
 from schema import Schema, Or, Optional
-from typing import Union
+from typing import Union, Tuple
 
 from .constants import PREDEFINED_VARIABLES
 from .util import parse_value
@@ -244,7 +244,7 @@ def _combine_values(v1: Union[str, list],
 
 
 def _split_sections_key(
-        sections_and_key: Union[str, list]) -> tuple[list, str]:
+        sections_and_key: Union[str, list]) -> Tuple[list, str]:
     '''
     Helper function to split a key into sections and the last key.
     '''

--- a/src/docthing/documentation_blob.py
+++ b/src/docthing/documentation_blob.py
@@ -74,8 +74,7 @@ class DocumentationNode(TreeNode):
             raise ValueError('Both content and children cannot be provided')
 
         if content is not None and not isinstance(
-                content, str) and not isinstance(
-                content, ResourceReference):
+                content, (str, list, ResourceReference, Document)):
             raise ValueError(
                 'content must be None, a path to a file or a ResourceReference')
 

--- a/src/docthing/documentation_content.py
+++ b/src/docthing/documentation_content.py
@@ -15,6 +15,7 @@ class ResourceReference(ABC):
     A class that represents a reference to a resource.
     '''
 
+    @staticmethod
     def search(line):
         '''
         Searches for a resource reference in the given line.

--- a/src/docthing/plugins/exporter/markdown.py
+++ b/src/docthing/plugins/exporter/markdown.py
@@ -12,12 +12,6 @@ class MarkdownExporter(Exporter):
     An exporter that exports documentation to Markdown format.
     '''
 
-    def __init__(self, documentation_blob):
-        '''
-        Initializes the MarkdownExporter instance with the provided DocumentationBlob instance.
-        '''
-        super().__init__(documentation_blob)
-
     def _enable(self):
         pass
 

--- a/src/docthing/plugins/exporter_interface.py
+++ b/src/docthing/plugins/exporter_interface.py
@@ -7,7 +7,6 @@ from abc import abstractmethod
 import os
 
 from ..documentation_content import ResourceReference
-
 from .plugin_interface import PluginInterface
 from ..util import mkdir_silent
 

--- a/src/docthing/plugins/manager.py
+++ b/src/docthing/plugins/manager.py
@@ -21,8 +21,7 @@ class PluginManager:
         self.plugins = builtin_plugins
 
     def enable_plugins(self,
-                       plugins: Union[str,
-                                      list[str]] = 'all',
+                       plugins: Union[str, list[str]] = 'all',
                        configs: dict = {}) -> None:
         '''
         Enable all plugins from the specified directory.
@@ -65,7 +64,7 @@ class PluginManager:
         if os.path.isdir(self.plugin_dir):
             for filename in os.listdir(self.plugin_dir):
                 if filename.endswith('.py'):
-                    res.push(filename)
+                    res.append(filename)
         return res
 
     def get_plugins(self):

--- a/src/docthing/plugins/manager.py
+++ b/src/docthing/plugins/manager.py
@@ -6,6 +6,7 @@ END FILE DOCUMENTATION '''
 import os
 import importlib.util
 import inspect
+from typing import Union
 
 from .plugin_interface import PluginInterface
 from ..util import get_docthing_plugin_dir
@@ -19,15 +20,23 @@ class PluginManager:
         self.plugin_dir = get_docthing_plugin_dir(plugin_type)
         self.plugins = builtin_plugins
 
-    def enable_plugins(self, plugins='all'):
+    def enable_plugins(self,
+                       plugins: Union[str,
+                                      list[str]] = 'all',
+                       configs: dict = {}) -> None:
         '''
         Enable all plugins from the specified directory.
+
+            Args:
+                plugins (str or list): The name of a plugin or the list of
+                names of the plugins to enable or 'all' to enable all plugins.
+                config (dict): The configuration dictionary.
         '''
         if plugins != 'all' and not isinstance(plugins, list):
             if isinstance(plugins, str):
                 plugins = [plugins]
             else:
-                raise Exception('Plugins must be a list of plugin names.')
+                raise ValueError('Plugins must be a list of plugin names.')
 
         # Load all plugins from the plugin directory
         for f in self._get_plugins_from_plugin_dir():
@@ -35,7 +44,8 @@ class PluginManager:
 
         if plugins == 'all':
             for plugin in self.plugins:
-                plugin.enable()
+                c = {"config": configs.get(plugin.get_name(), {})}
+                plugin.enable(**c)
             return
 
         avail_plugins = [p.get_name() for p in self.plugins]
@@ -47,7 +57,8 @@ class PluginManager:
         # Enable the specified plugins
         for plugin in self.plugins:
             if plugin.get_name() in plugins:
-                plugin.enable()
+                c = {"config": configs.get(plugin.get_name(), {})}
+                plugin.enable(**c)
 
     def _get_plugins_from_plugin_dir(self):
         res = []

--- a/src/docthing/plugins/manager.py
+++ b/src/docthing/plugins/manager.py
@@ -6,7 +6,7 @@ END FILE DOCUMENTATION '''
 import os
 import importlib.util
 import inspect
-from typing import Union
+from typing import Union, List
 
 from .plugin_interface import PluginInterface
 from ..util import get_docthing_plugin_dir
@@ -21,7 +21,7 @@ class PluginManager:
         self.plugins = builtin_plugins
 
     def enable_plugins(self,
-                       plugins: Union[str, list[str]] = 'all',
+                       plugins: Union[str, List[str]] = 'all',
                        configs: dict = {}) -> None:
         '''
         Enable all plugins from the specified directory.

--- a/src/docthing/plugins/meta_interpreter/nav.py
+++ b/src/docthing/plugins/meta_interpreter/nav.py
@@ -12,9 +12,8 @@ class MarkdownNAVInterpreter(MetaInterpreter):
     A meta-interpreter for interpreting PlantUML code blocks.
     '''
 
-    def __init__(self, config):
-        super().__init__(config, 'end_file')
-        self.config = config
+    def __init__(self):
+        super().__init__('end_file')
 
     def get_name(self):
         return 'nav.md'

--- a/src/docthing/plugins/meta_interpreter/plantuml.py
+++ b/src/docthing/plugins/meta_interpreter/plantuml.py
@@ -12,10 +12,6 @@ class PlantUMLInterpreter(MetaInterpreter):
     A meta-interpreter for interpreting PlantUML code blocks.
     '''
 
-    def __init__(self, config):
-        super().__init__(config)
-        self.config = config
-
     def get_name(self):
         return 'plantuml'
 

--- a/src/docthing/plugins/meta_interpreter/plantuml.py
+++ b/src/docthing/plugins/meta_interpreter/plantuml.py
@@ -62,4 +62,5 @@ class PlantUMLReference(ResourceReference):
             )
             return completed_process.stdout
         except sp.CalledProcessError as e:
-            raise Exception(f'Error while compiling PlantUML code: {e.stderr}')
+            raise ValueError(
+                f'A PlantUML compilation error was encountered: {e.stderr}')

--- a/src/docthing/plugins/meta_interpreter_interface.py
+++ b/src/docthing/plugins/meta_interpreter_interface.py
@@ -25,17 +25,16 @@ class MetaInterpreter(PluginInterface):
     MetaInterpreter is an abstract class that defines the interface for meta-interpreters.
     '''
 
-    def __init__(self, config, mode='block'):
+    def __init__(self, mode='block'):
         '''
-        Initializes the MetaInterpreter instance with the provided configuration.
+        Initializes the MetaInterpreter instance.
         '''
         if mode not in ['block', 'begin_file', 'end_file']:
             raise ValueError(
                 f'Mode {mode} is not supported. ' +
                 'Please use either \'block\', \'begin_file\' or \'end_file\'.')
 
-        super().__init__(config)
-        self.config = config
+        super().__init__()
         self.mode = mode
 
     def _enable(self):

--- a/src/docthing/plugins/meta_interpreter_interface.py
+++ b/src/docthing/plugins/meta_interpreter_interface.py
@@ -30,7 +30,7 @@ class MetaInterpreter(PluginInterface):
         Initializes the MetaInterpreter instance with the provided configuration.
         '''
         if mode not in ['block', 'begin_file', 'end_file']:
-            raise Exception(
+            raise ValueError(
                 f'Mode {mode} is not supported. ' +
                 'Please use either \'block\', \'begin_file\' or \'end_file\'.')
 
@@ -43,8 +43,8 @@ class MetaInterpreter(PluginInterface):
         Loads the MetaInterpreter instance by checking if the dependencies are available.
         '''
         if not self.are_dependencies_available():
-            raise Exception('Dependencies for the ' +
-                            f'{self.get_name()} interpreter are not available.')
+            raise ValueError('Dependencies for the ' +
+                             f'{self.get_name()} interpreter are not available.')
 
     def _disable(self):
         '''

--- a/src/docthing/plugins/plugin_interface.py
+++ b/src/docthing/plugins/plugin_interface.py
@@ -6,6 +6,7 @@ END FILE DOCUMENTATION '''
 from abc import ABC, abstractmethod
 import shutil
 from schema import Schema
+from typing import List
 
 
 class PluginInterface(ABC):
@@ -77,7 +78,7 @@ class PluginInterface(ABC):
         pass
 
     @abstractmethod
-    def get_dependencies(self) -> list[str]:
+    def get_dependencies(self) -> List[str]:
         '''
         Return the list of dependencies required by the plugin.
         '''

--- a/src/docthing/plugins/plugin_interface.py
+++ b/src/docthing/plugins/plugin_interface.py
@@ -101,7 +101,7 @@ class PluginInterface(ABC):
         '''
         return Schema(dict)
 
-    def validate(self, config: dict) -> bool:
+    def validate(self, config: dict):
         '''
         Validate the provided configuration for the plugin.
         '''
@@ -119,7 +119,8 @@ class PluginInterface(ABC):
         '''
         Configure the plugin with the provided configuration.
         '''
-        if self.validate(config):
+        validated_config = self.validate(config)
+        if config == validated_config:
             self._configure(config)
         else:
             raise ValueError('invalid configuration for plugin ' +

--- a/src/docthing/plugins/plugin_interface.py
+++ b/src/docthing/plugins/plugin_interface.py
@@ -16,11 +16,10 @@ class PluginInterface(ABC):
     initialization and cleanup, respectively.
     '''
 
-    def __init__(self, documentation_blob):
+    def __init__(self):
         '''
-        Initialize the plugin with the provided DocumentationBlob instance.
+        Initialize the plugin.
         '''
-        self.documentation_blob = documentation_blob
         self.enabled = False
 
     @abstractmethod

--- a/src/docthing/util.py
+++ b/src/docthing/util.py
@@ -112,7 +112,7 @@ def get_docthing_plugin_dir(plugin_type=None):
     If `plugin_type` is provided the path to the subdirectory is returned.
     '''
     if plugin_type not in SUPPORTED_PLUGIN_TYPES:
-        raise Exception('Plugin type not supported.')
+        raise ValueError('Plugin type not supported.')
 
     res = get_docthing_datadir() / 'plugins'
     if plugin_type:

--- a/tests/docthing/plugins/test_exporter_interface.py
+++ b/tests/docthing/plugins/test_exporter_interface.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: MIT
+import pytest
+from unittest.mock import MagicMock, patch, mock_open
+
+from docthing.plugins.exporter_interface import Exporter
+from docthing.documentation_content import ResourceReference
+from docthing.documentation_blob import DocumentationBlob
+
+
+class MockResourceReference(ResourceReference):
+    """
+    Mock implementation of the ResourceReference class for testing purposes.
+    """
+
+    def compile(self):
+        return "compiled_resource"
+
+    def get_ext(self):
+        return "mock_ext"
+
+
+class MockExporter(Exporter):
+    """
+    Mock implementation of the Exporter class for testing purposes.
+    """
+
+    def _export_leaf(self, leaf, output_file_no_ext):
+        """
+        Mock export logic for leaf nodes.
+        """
+        with open(f"{output_file_no_ext}.mock", "w") as f:
+            f.write(f"Exported leaf: {leaf.get_title()}")
+
+    def import_function(self, leaf_title, resource):
+        """
+        Mock import logic for external resources.
+        """
+        return f"imported:{resource}"
+
+    def _disable(self):
+        pass
+
+    def _enable(self):
+        pass
+
+    def get_dependencies(self):
+        return []
+
+    def get_description(self):
+        return "mock description"
+
+    def get_name(self):
+        return "mock-exporter"
+
+
+@pytest.fixture
+def mock_documentation_blob(tmp_path):
+    """
+    Fixture to create a mock DocumentationBlob with sample nodes.
+    """
+    parser_config = {"extensions": ["md"], "iexts": []}
+    index_file = tmp_path / "index.json"
+
+    # Write a mock index file
+    index_file.write_text(
+        """
+        {
+            "main-title": "Main",
+            "quick": "quick.md",
+            "intro": "intro.md",
+            "Chapter 1": {
+                "Section 1.1": "section1_1.md",
+                "Section 1.2": "section1_2.md"
+            }
+        }
+        """
+    )
+
+    return DocumentationBlob(
+        index_file=str(index_file),
+        parser_config=parser_config)
+
+
+@patch("os.makedirs")
+@patch("docthing.plugins.exporter_interface.mkdir_silent")
+@patch("builtins.open", mock_open(read_data="data"))
+def test_export(
+        mock_mkdir_silent,
+        mock_documentation_blob,
+        tmp_path):
+    """
+    Test the export method of the MockExporter class.
+    """
+    exporter = MockExporter()
+    output_dir = tmp_path / "output"
+
+    # Mock methods on the documentation blob
+    mock_documentation_blob.unlazy = MagicMock()
+    mock_documentation_blob.is_lazy = MagicMock(return_value=True)
+    mock_documentation_blob.get_leaves = MagicMock(
+        return_value=[
+            MagicMock(
+                get_title=MagicMock(return_value="Leaf 1"),
+                get_path=MagicMock(return_value=[
+                    MagicMock(get_title=MagicMock(return_value="Chapter 1")),
+                    MagicMock(get_title=MagicMock(
+                        return_value="Section 1.1")),
+                ]),
+                replace_resources_with_imports=MagicMock(),
+                get_content=MagicMock(return_value=[]),
+            )
+        ]
+    )
+
+    # Call the export method
+    exporter.export(mock_documentation_blob, str(output_dir))
+
+    # Assertions
+    mock_documentation_blob.unlazy.assert_called_once()
+    mock_mkdir_silent.assert_any_call(str(output_dir))
+    leaf = mock_documentation_blob.get_leaves.return_value[0]
+    leaf.replace_resources_with_imports.assert_called_with(
+        exporter.import_function)
+
+
+def test_export_leaf_resources(mock_documentation_blob, tmp_path):
+    """
+    Test the _export_leaf_resources method.
+    """
+    exporter = MockExporter()
+    leaf = MagicMock(
+        get_content=MagicMock(
+            return_value=[
+                MockResourceReference("img", "path/to/resource"),
+                "Some text",
+                MockResourceReference("img", "path/to/another_resource"),
+            ]
+        )
+    )
+    output_file_no_ext = tmp_path / "exported_leaf"
+
+    # Mock the MockResourceReference write method
+    with patch.object(MockResourceReference, "write") as mock_write:
+        exporter._export_leaf_resources(leaf, str(output_file_no_ext))
+
+        # Assertions
+        assert mock_write.call_count == 2
+        mock_write.assert_any_call(str(output_file_no_ext))
+
+
+def test_import_function():
+    """
+    Test the import_function method of MockExporter.
+    """
+    exporter = MockExporter()
+    result = exporter.import_function("Leaf Title", "Resource")
+    assert result == "imported:Resource"

--- a/tests/docthing/plugins/test_manager.py
+++ b/tests/docthing/plugins/test_manager.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+import pytest
+from unittest.mock import MagicMock, patch
+from schema import Schema
+
+from docthing.plugins.manager import PluginManager
+from docthing.plugins.plugin_interface import PluginInterface
+
+
+class MockPlugin1(PluginInterface):
+    """
+    A mock implementation of PluginInterface for testing purposes.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.dependencies = ["python", "git"]
+        self.configured = False
+
+    def _enable(self):
+        pass
+
+    def _disable(self):
+        pass
+
+    def get_name(self):
+        return "MockPlugin1"
+
+    def get_description(self):
+        return "A mock plugin for testing purposes."
+
+    def get_dependencies(self):
+        return self.dependencies
+
+    def schema(self):
+        return Schema({"key": dict})
+
+    def _configure(self, _config: dict):
+        self.configured = True
+
+
+class MockPlugin2(PluginInterface):
+    """
+    A mock implementation of PluginInterface for testing purposes.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.dependencies = ["python", "git"]
+        self.configured = False
+
+    def _enable(self):
+        pass
+
+    def _disable(self):
+        pass
+
+    def get_name(self):
+        return "MockPlugin2"
+
+    def get_description(self):
+        return "A mock plugin for testing purposes."
+
+    def get_dependencies(self):
+        return self.dependencies
+
+    def schema(self):
+        return Schema({"key": dict})
+
+    def _configure(self, _config: dict):
+        self.configured = True
+
+
+@pytest.fixture
+def mock_plugin_dir(tmp_path):
+    """
+    Fixture to create a mock plugin directory.
+    """
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin1.py").write_text("class Plugin1: pass")
+    (plugin_dir / "plugin2.py").write_text("class Plugin2: pass")
+    return str(plugin_dir)
+
+
+@pytest.fixture
+def mock_plugins():
+    """
+    Fixture to provide mock plugins.
+    """
+    return [
+        MockPlugin1(),
+        MockPlugin2(),
+    ]
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+@patch("docthing.util.get_docthing_plugin_dir", new=mock_plugin_dir)
+def test_plugin_manager_initialization(mock_plugins):
+    """
+    Test PluginManager initialization.
+    """
+    manager = PluginManager("mock_type", builtin_plugins=mock_plugins)
+    assert len(manager.plugins) == 2
+    assert manager.plugins[0].get_name() == "MockPlugin1"
+    assert manager.plugins[1].get_name() == "MockPlugin2"
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+@patch("docthing.util.get_docthing_plugin_dir")
+def test_enable_plugins_all(mock_get_dir, mock_plugins, tmp_path):
+    """
+    Test enabling all plugins.
+    """
+    mock_get_dir.return_value = str(tmp_path)
+    manager = PluginManager("mock_type", builtin_plugins=mock_plugins)
+
+    configs = {
+        "MockPlugin1": {"key": {"setting": "value1"}},
+        "MockPlugin2": {"key": {"setting": "value1"}}
+    }
+    manager.enable_plugins(plugins="all", configs=configs)
+
+    assert all(plugin.enabled for plugin in mock_plugins)
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+@patch("docthing.util.get_docthing_plugin_dir")
+def test_enable_specific_plugins(mock_get_dir, mock_plugins, tmp_path):
+    """
+    Test enabling specific plugins.
+    """
+    mock_get_dir.return_value = str(tmp_path)
+    manager = PluginManager("mock_type", builtin_plugins=mock_plugins)
+
+    configs = {
+        "MockPlugin1": {"key": {"setting": "value1"}},
+        "MockPlugin2": {"key": {"setting": "value1"}}
+    }
+    manager.enable_plugins(plugins=["MockPlugin1"], configs=configs)
+
+    assert mock_plugins[0].enabled
+    assert not mock_plugins[1].enabled
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+@patch("docthing.util.get_docthing_plugin_dir")
+def test_disable_plugins(mock_get_dir, mock_plugins, tmp_path):
+    """
+    Test disabling all plugins.
+    """
+    mock_get_dir.return_value = str(tmp_path)
+    manager = PluginManager("mock_type", builtin_plugins=mock_plugins)
+
+    # Enable plugins first
+    for plugin in manager.plugins:
+        plugin.enable({"key": {"setting": "value1"}})
+
+    # Disable plugins
+    manager.disable_plugins()
+
+    assert all(not plugin.enabled for plugin in mock_plugins)
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+@patch("os.listdir")
+@patch("os.path.isdir")
+def test_get_plugins_from_plugin_dir(mock_isdir, mock_listdir, tmp_path):
+    """
+    Test retrieving plugins from the plugin directory.
+    """
+    mock_isdir.return_value = True
+    mock_listdir.return_value = [
+        "plugin1.py", "plugin2.py", "not_a_plugin.txt"]
+
+    manager = PluginManager("mock_type")
+    plugins = manager._get_plugins_from_plugin_dir()
+
+    assert "plugin1.py" in plugins
+    assert "plugin2.py" in plugins
+    assert "not_a_plugin.txt" not in plugins
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+@patch("importlib.util.spec_from_file_location")
+@patch("importlib.util.module_from_spec")
+def test_load_from_file(mock_module_from_spec, mock_spec_from_file_location):
+    """
+    Test loading a plugin from a file.
+    """
+    mock_spec = MagicMock()
+    mock_spec_from_file_location.return_value = mock_spec
+
+    mock_module = MagicMock()
+    mock_module_from_spec.return_value = mock_module
+
+    mock_module.Plugin1 = MockPlugin1
+
+    manager = PluginManager("mock_type")
+    manager._load_from_file("mock_path/plugin1.py")
+
+    assert len(manager.plugins) == 1
+    assert isinstance(manager.plugins[0], MockPlugin1)
+
+
+@patch("docthing.util.SUPPORTED_PLUGIN_TYPES", new=["mock_type"])
+def test_enable_plugins_invalid_type(mock_plugins):
+    """
+    Test enabling plugins with an invalid type.
+    """
+    manager = PluginManager("mock_type", builtin_plugins=mock_plugins)
+
+    with pytest.raises(ValueError, match="Plugins must be a list of plugin names."):
+        manager.enable_plugins(plugins=123)

--- a/tests/docthing/plugins/test_plugin_interface.py
+++ b/tests/docthing/plugins/test_plugin_interface.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: MIT
+import pytest
+from unittest.mock import MagicMock, patch
+from schema import Schema, SchemaError
+
+from docthing.plugins.plugin_interface import PluginInterface
+
+
+class MockPlugin(PluginInterface):
+    """
+    A mock implementation of PluginInterface for testing purposes.
+    """
+
+    def __init__(self):
+        self.dependencies = ["python", "git"]
+        self.configured = False
+
+    def _enable(self):
+        pass
+
+    def _disable(self):
+        pass
+
+    def get_name(self):
+        return "MockPlugin"
+
+    def get_description(self):
+        return "A mock plugin for testing purposes."
+
+    def get_dependencies(self):
+        return self.dependencies
+
+    def schema(self):
+        return Schema({"key": str})
+
+    def _configure(self, _config: dict):
+        self.configured = True
+
+
+@pytest.fixture
+def mock_documentation_blob():
+    """
+    Fixture to provide a mock DocumentationBlob instance.
+    """
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_plugin(mock_documentation_blob):
+    """
+    Fixture to provide an instance of MockPlugin.
+    """
+    return MockPlugin()
+
+
+def test_plugin_enable(mock_plugin):
+    """
+    Test the enable method of PluginInterface.
+    """
+    config = {"key": "value"}
+    mock_plugin.enable(config=config)
+
+    assert mock_plugin.is_enabled()
+    assert mock_plugin.configured
+    assert mock_plugin.enabled
+
+
+def test_plugin_disable(mock_plugin):
+    """
+    Test the disable method of PluginInterface.
+    """
+    mock_plugin.enable(config={"key": "value"})
+    assert mock_plugin.is_enabled()
+
+    mock_plugin.disable()
+    assert not mock_plugin.is_enabled()
+
+
+def test_plugin_dependencies_available(mock_plugin):
+    """
+    Test the are_dependencies_available method.
+    """
+    with patch("shutil.which", return_value=True):
+        assert mock_plugin.are_dependencies_available()
+
+    with patch("shutil.which", side_effect=lambda x: x != "git"):
+        assert not mock_plugin.are_dependencies_available()
+
+
+def test_plugin_validate_config_success(mock_plugin):
+    """
+    Test configuration validation with a valid config.
+    """
+    config = {"key": "value"}
+    validated = mock_plugin.validate(config)
+
+    assert validated == config
+
+
+def test_plugin_validate_config_failure(mock_plugin):
+    """
+    Test configuration validation with an invalid config.
+    """
+    config = {"key": 123}  # 'key' should be a string according to the schema
+    with pytest.raises(SchemaError):
+        mock_plugin.validate(config)
+
+
+def test_plugin_configure(mock_plugin):
+    """
+    Test the configure method.
+    """
+    config = {"key": "value"}
+    mock_plugin.configure(config)
+
+    assert mock_plugin.configured
+
+
+def test_plugin_invalid_configuration(mock_plugin):
+    """
+    Test configuring the plugin with an invalid configuration.
+    """
+    config = {"key": 123}  # 'key' should be a string according to the schema
+    with pytest.raises(SchemaError):
+        mock_plugin.configure(config)
+
+
+def test_plugin_get_name(mock_plugin):
+    """
+    Test the get_name method.
+    """
+    assert mock_plugin.get_name() == "MockPlugin"
+
+
+def test_plugin_get_description(mock_plugin):
+    """
+    Test the get_description method.
+    """
+    assert mock_plugin.get_description() == "A mock plugin for testing purposes."
+
+
+def test_plugin_get_dependencies(mock_plugin):
+    """
+    Test the get_dependencies method.
+    """
+    assert mock_plugin.get_dependencies() == ["python", "git"]

--- a/tests/docthing/test_documentation_blob.py
+++ b/tests/docthing/test_documentation_blob.py
@@ -128,9 +128,7 @@ def test_invalid_content_and_children(mock_config):
         )
 
 
-class TestReference(ResourceReference):
-    __test__ = False
-
+class MockReference(ResourceReference):
     def __init__(self, path_to_file):
         super().__init__(None, 'import-file', use_hash=path_to_file)
 
@@ -145,7 +143,7 @@ def test_replace_resources_with_imports(mock_config):
     node = DocumentationNode(
         parent=None,
         title="Replace Resources",
-        content=Document([TestReference("resource.ext")]),
+        content=Document([MockReference("resource.ext")]),
         parser_config=mock_config
     )
     mock_import = MagicMock()

--- a/tests/docthing/test_documentation_blob.py
+++ b/tests/docthing/test_documentation_blob.py
@@ -1,0 +1,214 @@
+# SPDX-License-Identifier: MIT
+
+import pytest
+import os
+from unittest.mock import MagicMock  # , patch
+from typing import Union
+
+from docthing.documentation_blob import DocumentationNode  # , DocumentationBlob
+from docthing.documentation_content import Document, ResourceReference
+
+
+# Mock and fixtures
+
+@pytest.fixture
+def mock_config():
+    return {
+        "extensions": ["md", "txt"],
+        "iexts": [],
+        "doc_level": 1
+    }
+
+
+@pytest.fixture
+def mock_index_file():
+    return "index.json"
+
+
+# Documentation Node
+
+def test_initialize_leaf_node(mock_config, monkeypatch):
+    monkeypatch.setattr(os.path, "isfile", lambda x: True)
+    node = DocumentationNode(
+        parent=None,
+        title="Leaf Node",
+        content="content.md",
+        parser_config=mock_config
+    )
+    assert node.get_title() == "Leaf Node"
+    assert node.get_content() == "content.md"
+    assert node.is_lazy()
+
+
+def test_initialize_internal_node(mock_config):
+    child = DocumentationNode(
+        parent=None,
+        title="Child Node",
+        content="child.md",
+        parser_config=mock_config
+    )
+    parent = DocumentationNode(
+        parent=None,
+        title="Parent Node",
+        children=[child]
+    )
+    assert not parent.is_leaf()
+    assert parent.get_title() == "Parent Node"
+
+
+def test_unlazy_content_file(mock_config, monkeypatch):
+    monkeypatch.setattr(os.path, "isfile", lambda x: True)
+    node = DocumentationNode(
+        parent=None,
+        title="Lazy Node",
+        content="test_file.md",
+        parser_config=mock_config
+    )
+    extract_documentation = MagicMock(
+        return_value=(["Extracted Content"], {"level": 1}))
+    monkeypatch.setattr(
+        "docthing.documentation_blob.extract_documentation",
+        extract_documentation)
+
+    node._unlazy_content()
+
+    assert node.get_content().content == ["Extracted Content"]
+    assert not node.is_lazy()
+
+
+# def test_unlazy_content_directory(mock_config, monkeypatch):
+#     monkeypatch.setattr(os.path, "isdir", lambda x: True)
+#     monkeypatch.setattr(os, "listdir", lambda x: ["file1.md", "file2.txt"])
+#     node = DocumentationNode(
+#         parent=None,
+#         title="Lazy Dir Node",
+#         content="test_dir",
+#         parser_config=mock_config
+#     )
+#     extract_documentation = MagicMock(
+#         side_effect=(["File 1 Content"], {"level": 1})
+#     )
+#     monkeypatch.setattr(
+#         "docthing.documentation_blob.extract_documentation",
+#         extract_documentation)
+
+#     node._unlazy_content()
+
+#     assert isinstance(node.get_content(), Document)
+#     assert node.get_content().content
+#     assert len(node.get_content().content) == 2
+
+
+def test_get_options(mock_config, monkeypatch):
+    monkeypatch.setattr(os.path, "isfile", lambda x: True)
+    node = DocumentationNode(
+        parent=None,
+        title="Option Node",
+        content="test.md",
+        parser_config=mock_config
+    )
+    extract_documentation = MagicMock(
+        return_value=(["Content"], {"level": 2, "level-only": True}))
+    monkeypatch.setattr(
+        "docthing.documentation_blob.extract_documentation",
+        extract_documentation)
+
+    node._unlazy_content()
+
+    assert node.get_options() == {"level": 2, "level-only": True}
+
+
+def test_invalid_content_and_children(mock_config):
+    with pytest.raises(ValueError):
+        DocumentationNode(
+            parent=None,
+            title="Invalid Node",
+            content="content.md",
+            children=[]
+        )
+
+
+class TestReference(ResourceReference):
+    __test__ = False
+
+    def __init__(self, path_to_file):
+        super().__init__(None, 'import-file', use_hash=path_to_file)
+
+    def get_ext(self):
+        return 'ext'
+
+    def compile(self) -> Union[bytes, str]:
+        return None
+
+
+def test_replace_resources_with_imports(mock_config):
+    node = DocumentationNode(
+        parent=None,
+        title="Replace Resources",
+        content=Document([TestReference("resource.ext")]),
+        parser_config=mock_config
+    )
+    mock_import = MagicMock()
+    node.replace_resources_with_imports(mock_import)
+    mock_import.assert_called()
+
+
+# Documentation Blob
+
+# @patch("builtins.open", create=True)
+# @patch("json.load")
+# def test_generate_tree_from_index(
+#         mock_json_load,
+#         mock_open,
+#         mock_config,
+#         mock_index_file):
+#     mock_json_load.return_value = {
+#         "main-title": "Main Title",
+#         "intro": "intro.md",
+#         "quick": "quick.md",
+#         "extra": {
+#             "Section": "section.md"
+#         }
+#     }
+#     blob = DocumentationBlob(mock_index_file, mock_config)
+
+#     assert blob.root.get_title() == "Main Title"
+#     assert len(blob.root.get_children()) == 3
+
+
+# def test_unlazy_blob(mock_index_file, mock_config):
+#     mock_node = MagicMock(spec=DocumentationNode)
+#     mock_node.is_lazy.return_value = True
+
+#     blob = DocumentationBlob(mock_index_file, mock_config)
+#     blob.root = mock_node
+
+#     blob.unlazy()
+
+#     mock_node.unlazy.assert_called_once()
+
+
+# def test_prune_doc(mock_index_file, mock_config):
+#     mock_node = MagicMock(spec=DocumentationNode)
+#     mock_node.get_content.return_value = "test content"
+#     mock_node.get_options.return_value = {"level": 3, "level-only": False}
+
+#     blob = DocumentationBlob(mock_index_file, mock_config)
+#     blob.root = mock_node
+
+#     blob.prune_doc()
+
+#     mock_node.unlazy.assert_called_once()
+
+
+# @patch("builtins.open", create=True)
+# @patch("json.load")
+# def test_invalid_index_file(
+#         mock_json_load,
+#         mock_open,
+#         mock_config,
+#         mock_index_file):
+#     mock_json_load.side_effect = ValueError
+
+#     with pytest.raises(ValueError):
+#         DocumentationBlob(mock_index_file, mock_config)

--- a/tests/docthing/test_documentation_content.py
+++ b/tests/docthing/test_documentation_content.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: MIT
 
-# test_resource_document.py
 import pytest
 import re
 
@@ -10,9 +9,7 @@ from docthing.util import sha256sum
 
 # Concrete implementation of ResourceReference for testing purposes
 
-class TestResourceReference(ResourceReference):
-    __test__ = False
-
+class MockResourceReference(ResourceReference):
     def get_ext(self):
         return 'txt'
 
@@ -33,40 +30,40 @@ class TestResourceReferenceClass:
 
     def test_init_with_hash(self):
         source = ['line1', 'line2']
-        ref = TestResourceReference(source, 'type1', use_hash=True)
+        ref = MockResourceReference(source, 'type1', use_hash=True)
         expected_hash = sha256sum(''.join(source))
         assert ref.get_hash() == expected_hash
 
     def test_init_without_hash(self):
-        ref = TestResourceReference(['line1'], 'type1', use_hash=False)
+        ref = MockResourceReference(['line1'], 'type1', use_hash=False)
         assert ref.get_hash() is None
 
     def test_init_with_custom_hash(self):
         custom_hash = 'custom_hash'
-        ref = TestResourceReference(['line1'], 'type1', use_hash=custom_hash)
+        ref = MockResourceReference(['line1'], 'type1', use_hash=custom_hash)
         assert ref.get_hash() == custom_hash
 
     def test_init_invalid_hash(self):
         with pytest.raises(ValueError, match='use_hash must be a boolean or a string'):
-            TestResourceReference(['line1'], 'type1', use_hash=123)
+            MockResourceReference(['line1'], 'type1', use_hash=123)
 
     def test_get_path_with_hash(self):
         source = ['line1']
-        ref = TestResourceReference(source, 'type1', use_hash=True)
+        ref = MockResourceReference(source, 'type1', use_hash=True)
         expected_hash = sha256sum(''.join(source))
         assert ref.get_path() == f'{expected_hash}.txt'
 
     def test_get_path_without_hash(self):
-        ref = TestResourceReference(['line1'], 'type1', use_hash=False)
+        ref = MockResourceReference(['line1'], 'type1', use_hash=False)
         assert ref.get_path() == '.txt'
 
     def test_get_path_with_custom_hash(self):
         custom_hash = 'custom_string'
-        ref = TestResourceReference(['line1'], 'type1', use_hash=custom_hash)
+        ref = MockResourceReference(['line1'], 'type1', use_hash=custom_hash)
         assert ref.get_path() == f'{custom_hash}.txt'
 
     def test_str_representation(self):
-        ref = TestResourceReference(['line1'], 'type1', use_hash=False)
+        ref = MockResourceReference(['line1'], 'type1', use_hash=False)
         assert str(ref) == '@ref(type1)-->[.txt]\n'
 
 
@@ -92,7 +89,7 @@ class TestDocument:
 
     def test_replace_lines_with_reference(self):
         content = ['line1\n', 'line2\n', 'line3\n']
-        ref = TestResourceReference(['source'], 'type1')
+        ref = MockResourceReference(['source'], 'type1')
         doc = Document(content)
         doc.replace_lines_with_reference(ref, 1, 2)
         assert doc.content == ['line1\n', ref]
@@ -104,7 +101,7 @@ class TestDocument:
 
     def test_replace_lines_with_reference_invalid_indices(self):
         doc = Document(['line1', 'line2'])
-        ref = TestResourceReference(['source'], 'type1')
+        ref = MockResourceReference(['source'], 'type1')
         with pytest.raises(ValueError, match='begin and end must be integers'):
             doc.replace_lines_with_reference(ref, 'a', 1)
 
@@ -128,7 +125,7 @@ class TestDocument:
         assert doc.content == ['line1', 'line2', 'new line']
 
     def test_get_printable(self):
-        content = ['line1\n', TestResourceReference(['source'], 'type1')]
+        content = ['line1\n', MockResourceReference(['source'], 'type1')]
         doc = Document(content)
 
         assert re.match(
@@ -136,6 +133,6 @@ class TestDocument:
             doc.get_printable()) is not None
 
     def test_str_representation(self):
-        content = ['line1\n', TestResourceReference(['source'], 'type1')]
+        content = ['line1\n', MockResourceReference(['source'], 'type1')]
         doc = Document(content)
         assert str(doc) == 'Document(1 lines, 1 references)'

--- a/tests/docthing/test_documentation_content.py
+++ b/tests/docthing/test_documentation_content.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: MIT
+
+# test_resource_document.py
+import pytest
+import re
+
+from docthing.documentation_content import ResourceReference, Document
+from docthing.util import sha256sum
+
+
+# Concrete implementation of ResourceReference for testing purposes
+
+class TestResourceReference(ResourceReference):
+    __test__ = False
+
+    def get_ext(self):
+        return 'txt'
+
+    def compile(self, output_prefix):
+        return 'compiled_content'
+
+
+# Tests for ResourceReference
+
+class TestResourceReferenceClass:
+    def test_search_valid_reference(self):
+        line = '@ref(type1)-->[path/to/resource]'
+        assert ResourceReference.search(line) == ('type1', 'path/to/resource')
+
+    def test_search_invalid_reference(self):
+        line = 'Invalid reference'
+        assert ResourceReference.search(line) is None
+
+    def test_init_with_hash(self):
+        source = ['line1', 'line2']
+        ref = TestResourceReference(source, 'type1', use_hash=True)
+        expected_hash = sha256sum(''.join(source))
+        assert ref.get_hash() == expected_hash
+
+    def test_init_without_hash(self):
+        ref = TestResourceReference(['line1'], 'type1', use_hash=False)
+        assert ref.get_hash() is None
+
+    def test_init_with_custom_hash(self):
+        custom_hash = 'custom_hash'
+        ref = TestResourceReference(['line1'], 'type1', use_hash=custom_hash)
+        assert ref.get_hash() == custom_hash
+
+    def test_init_invalid_hash(self):
+        with pytest.raises(ValueError, match='use_hash must be a boolean or a string'):
+            TestResourceReference(['line1'], 'type1', use_hash=123)
+
+    def test_get_path_with_hash(self):
+        source = ['line1']
+        ref = TestResourceReference(source, 'type1', use_hash=True)
+        expected_hash = sha256sum(''.join(source))
+        assert ref.get_path() == f'{expected_hash}.txt'
+
+    def test_get_path_without_hash(self):
+        ref = TestResourceReference(['line1'], 'type1', use_hash=False)
+        assert ref.get_path() == '.txt'
+
+    def test_get_path_with_custom_hash(self):
+        custom_hash = 'custom_string'
+        ref = TestResourceReference(['line1'], 'type1', use_hash=custom_hash)
+        assert ref.get_path() == f'{custom_hash}.txt'
+
+    def test_str_representation(self):
+        ref = TestResourceReference(['line1'], 'type1', use_hash=False)
+        assert str(ref) == '@ref(type1)-->[.txt]\n'
+
+
+# Tests for Document
+
+class TestDocument:
+    def test_init_empty(self):
+        doc = Document()
+        assert doc.content == []
+
+    def test_init_with_string(self):
+        doc = Document('line1\nline2')
+        assert doc.content == ['line1\n', 'line2']
+
+    def test_init_with_list(self):
+        content = ['line1\n', 'line2']
+        doc = Document(content)
+        assert doc.content == content
+
+    def test_init_invalid_content(self):
+        with pytest.raises(ValueError, match='content must be a list of strings or ResourceReferences'):
+            Document(123)
+
+    def test_replace_lines_with_reference(self):
+        content = ['line1\n', 'line2\n', 'line3\n']
+        ref = TestResourceReference(['source'], 'type1')
+        doc = Document(content)
+        doc.replace_lines_with_reference(ref, 1, 2)
+        assert doc.content == ['line1\n', ref]
+
+    def test_replace_lines_with_reference_invalid_reference(self):
+        doc = Document(['line1', 'line2'])
+        with pytest.raises(ValueError, match='reference must be a ResourceReference'):
+            doc.replace_lines_with_reference('invalid', 0, 1)
+
+    def test_replace_lines_with_reference_invalid_indices(self):
+        doc = Document(['line1', 'line2'])
+        ref = TestResourceReference(['source'], 'type1')
+        with pytest.raises(ValueError, match='begin and end must be integers'):
+            doc.replace_lines_with_reference(ref, 'a', 1)
+
+    def test_replace_resources_with_imports(self):
+        def mock_import_function(title, el):
+            return f'imported_{el}'
+
+        doc = Document(['@ref(type1)-->[path/to/resource]', 'normal line'])
+        doc.replace_resources_with_imports('Title', mock_import_function)
+        assert doc.content == [
+            'imported_@ref(type1)-->[path/to/resource]', 'normal line']
+
+    def test_prepend_resource(self):
+        doc = Document(['line1', 'line2'])
+        doc.prepend_resource('new line')
+        assert doc.content == ['new line', 'line1', 'line2']
+
+    def test_append_resource(self):
+        doc = Document(['line1', 'line2'])
+        doc.append_resource('new line')
+        assert doc.content == ['line1', 'line2', 'new line']
+
+    def test_get_printable(self):
+        content = ['line1\n', TestResourceReference(['source'], 'type1')]
+        doc = Document(content)
+
+        assert re.match(
+            'line1\n@ref\\(type1\\)-->\\[[0-9a-f]{64}\\.txt\\]\n',
+            doc.get_printable()) is not None
+
+    def test_str_representation(self):
+        content = ['line1\n', TestResourceReference(['source'], 'type1')]
+        doc = Document(content)
+        assert str(doc) == 'Document(1 lines, 1 references)'

--- a/tests/docthing/test_util.py
+++ b/tests/docthing/test_util.py
@@ -1,0 +1,101 @@
+# SPDX-License-Identifier: MIT
+
+# test_utils.py
+import os
+import hashlib
+import pathlib
+import sys
+import pytest
+from unittest.mock import patch
+
+from docthing.util import mkdir_silent, parse_value, sha256sum
+from docthing.util import get_datadir, get_docthing_datadir, get_docthing_plugin_dir
+
+
+# Test mkdir_silent
+
+def test_mkdir_silent(tmp_path):
+    test_dir = tmp_path / "test_dir"
+    mkdir_silent(test_dir)
+    assert test_dir.exists()
+    assert test_dir.is_dir()
+
+
+def test_mkdir_silent_existing(tmp_path):
+    test_dir = tmp_path / "existing_dir"
+    os.makedirs(test_dir)
+    mkdir_silent(test_dir)  # Should not raise an exception
+    assert test_dir.exists()
+
+
+# Test parse_value
+
+@pytest.mark.parametrize("input_value, expected", [
+    ("true", True),
+    ("false", False),
+    ("null", None),
+    ("none", None),
+    ("42", 42),
+    ("3.14", 3.14),
+    ("a,b,c", ["a", "b", "c"]),
+    ("1,2,3", [1, 2, 3]),
+    ("", ""),
+    ("hello", "hello"),
+])
+def test_parse_value(input_value, expected):
+    assert parse_value(input_value) == expected
+
+
+# Test sha256sum
+
+def test_sha256sum():
+    test_string = "hello world"
+    expected_hash = hashlib.sha256(test_string.encode()).hexdigest()
+    assert sha256sum(test_string) == expected_hash
+
+
+# Test get_datadir
+
+def test_get_datadir_linux(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    home = pathlib.Path.home()
+    expected = home / ".local/share"
+    assert get_datadir() == expected
+
+
+def test_get_datadir_windows(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    home = pathlib.Path.home()
+    expected = home / "AppData/Roaming"
+    assert get_datadir() == expected
+
+
+def test_get_datadir_mac(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    home = pathlib.Path.home()
+    expected = home / "Library/Application Support"
+    assert get_datadir() == expected
+
+
+# Test get_docthing_datadir
+
+def test_get_docthing_datadir(monkeypatch):
+    mock_datadir = pathlib.Path("/mock/datadir")
+    with patch("docthing.util.get_datadir", return_value=mock_datadir):
+        assert get_docthing_datadir() == mock_datadir / "docthing"
+
+
+# Test get_docthing_plugin_dir
+
+def test_get_docthing_plugin_dir_valid_type(monkeypatch):
+    mock_datadir = pathlib.Path("/mock/datadir")
+    with patch("docthing.util.get_datadir", return_value=mock_datadir):
+        assert get_docthing_plugin_dir(
+            "meta-interpreter") == mock_datadir / "docthing/plugins/meta-interpreter"
+
+
+def test_get_docthing_plugin_dir_invalid_type(monkeypatch):
+    mock_datadir = pathlib.Path("/mock/datadir")
+    with patch("docthing.util.get_datadir", return_value=mock_datadir):
+        with pytest.raises(ValueError, match="Plugin type not supported."):
+            get_docthing_plugin_dir("unsupported_type")


### PR DESCRIPTION
## New features (closes #2)

- configuration file supports plugin-specific configuration
- plugin implementations can exploit the configurations passed in the config file

## Fix

- remove unused `documentation_blob` parameter from the `PluginInterface` constructor
- add tests for more classes (more than 50% coverage reached)