### PR TITLE
Add more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Documentation is crucial for maintaining a clear understanding of a project's ar
 - 🔌 Extensible (Plugins)
 - 🖼️ LOD (Level Of Details: choose the in-depth level of your documentation dynamically)
 
+### FAQ
+
+> **Q**: In which way `docthing` differs from other tools such as `doxygen` or `sphinx`?
+>
+> **A**: `docthing` is a tool that extracts *high-level documentation* from the projects. It is designed to be used alongside other tools such as `doxygen` or `sphinx` to provide a more comprehensive documentation solution. These tools are focused on generating technical documentation, while `docthing` is designed to extract high-level documentation from the projects and forcing developers to write and update it.
+
 ## Table of Contents
 
 - [Usage](#usage)

--- a/bin/pre-commit
+++ b/bin/pre-commit
@@ -31,7 +31,7 @@ echo "4. Running tests \`pytest\`"
 pytest
 echo
 
-# TODO: increase required coverate to al least 80
+# TODO: increase required coverage to al least 80
 echo "5. Running coverage \`pytest-cov\`"
 pytest --cov src --cov-fail-under 50
 echo

--- a/docthing.conf
+++ b/docthing.conf
@@ -46,7 +46,7 @@ begin_doc=BEGIN FILE DOCUMENTATION
 end_doc=END FILE DOCUMENTATION
 # max documentation level (see documentation for details)
 # 0 means no limit
-doc_level=1
+doc_level=0
 # extensions to parse (eg. if a directory is passed in the index file
 #    these will be used to find file to use to create documentation)
 extensions=py

--- a/docthing.jsonc
+++ b/docthing.jsonc
@@ -1,29 +1,29 @@
 {
-    "main-title": "docthing",
-    "quick": "README.md",
-    "intro": "INTRO.md",
-    // here a the general functioning of the project should be described
-    "How to: doc(your)thing": {
-        "Usage": "src/docthing/__main__.py",
-        "Examples": "src/docthing/__init__.py"
-    },
-    // here should be presented an in-depth on the configuration file
-    "Configuration": "src/docthing/config.py",
-    // here should be explained how to plugins system works
-    "Plugin Development": {
-        "Plugin": "src/docthing/plugins/plugin_interface.py",
-        "Plugin Manager": "src/docthing/plugins/manager.py",
-        "Documentation Tree": "src/docthing/documentation_blob.py",
-        "Documentation Leaf": "src/docthing/documentation_content.py",
-        "Plugin Types": {
-            "Meta Interpreter": "src/docthing/plugins/meta_interpreter_interface.py",
-            "Exporter": "src/docthing/plugins/exporter_interface.py"
-        }
-    },
-    // here should be explained how to contribute to the project it-self
-    "Development contribution": {
-        "Extractor": "src/docthing/extractor.py",
-        "Utils": "src/docthing/util.py",
-        "Constants": "src/docthing/constants.py"
+  "main-title": "docthing",
+  "quick": "README.md",
+  "intro": "INTRO.md",
+  // here a the general functioning of the project should be described
+  "How to: doc(your)thing": {
+    "Usage": "src/docthing/__main__.py",
+    "Examples": "src/docthing/__init__.py"
+  },
+  // here should be presented an in-depth on the configuration file
+  "Configuration": "src/docthing/config.py",
+  // here should be explained how to plugins system works
+  "Plugin Development": {
+    "Plugin": "src/docthing/plugins/plugin_interface.py",
+    "Plugin Manager": "src/docthing/plugins/manager.py",
+    "Documentation Tree": "src/docthing/documentation_blob.py",
+    "Documentation Leaf": "src/docthing/documentation_content.py",
+    "Plugin Types": {
+      "Meta Interpreter": "src/docthing/plugins/meta_interpreter_interface.py",
+      "Exporter": "src/docthing/plugins/exporter_interface.py"
     }
+  },
+  // here should be explained how to contribute to the project it-self
+  "Development": {
+    "Extractor": "src/docthing/extractor.py",
+    "Utils": "src/docthing/util.py",
+    "Constants": "src/docthing/constants.py"
+  }
 }

--- a/src/docthing/__main__.py
+++ b/src/docthing/__main__.py
@@ -27,13 +27,13 @@ END FILE DOCUMENTATION '''
 import os
 import argparse
 
-from docthing.plugins.meta_interpreter.nav import MarkdownNAVInterpreter
 from docthing.util import mkdir_silent
 from docthing.config import load_config, merge_configs, validate_config, get_as_dot_config
 from docthing.constants import DEFAULT_CONFIG_FILE, DEFAULT_OUTPUT_DIR, DEFAULT_CONFIG
 from docthing.documentation_blob import DocumentationBlob
 from docthing.plugins.manager import PluginManager
 from docthing.plugins.exporter.markdown import MarkdownExporter
+from docthing.plugins.meta_interpreter.nav import MarkdownNAVInterpreter
 from docthing.plugins.meta_interpreter.plantuml import PlantUMLInterpreter
 
 

--- a/src/docthing/constants.py
+++ b/src/docthing/constants.py
@@ -1,6 +1,27 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 3)
-TODO: constants documentation
+# Constants
+
+In the `docthing.constants` module, you will find the constants used in the
+docthing project.
+
+Here will be defined all the _default configuration values_ that can be
+overridden by the user, as well as the default configuration file containing
+the default values for the `parser` for the most common languages. For obvious
+reasons, this can't be an exhaustive list, but it will be updated as new
+languages are added to the project.
+
+If a language is not supported, this does not mean that `docthing` will not
+work with it. It simply means that the default configuration file for that
+language is not available and the user will have to provide their own.
+
+## Prederined Variables
+
+In this file a list of `PREDEFINED_VARIABLES` is defined. These variables
+are used to define the default values for the configuration file. Since these
+variables changes their value based on the user usage of the tool, they are
+actually function implementations that are called when the configuration
+file is parsed.
 END FILE DOCUMENTATION '''
 
 import os

--- a/src/docthing/constants.py
+++ b/src/docthing/constants.py
@@ -65,6 +65,12 @@ DEFAULT_CONFIG = {
         },
         'rs': _c_like_languages_parser_config,     # Rust
         'rlib': _c_like_languages_parser_config,   # Rust library
+        'sh': {                                    # Julia
+            'begin_ml_comment': '#',
+            'end_ml_comment': '#',
+            'allow_sl_comments': True,
+            'sl_comment': '#',
+        },
 
         # TODO: add more default configuration options for most common
         # languages here

--- a/src/docthing/documentation_blob.py
+++ b/src/docthing/documentation_blob.py
@@ -26,9 +26,9 @@ the hierarchical structure of documentation, where each node can have multiple c
 Each node with child(ren) is a _Section_ and outermost children (children of the root node) are referred
 as _Chapters_ (which are just sections with a fancy name).
 
-Each leaf of the tree represents a documentation content.
-
-
+Each leaf of the tree represents a documentation piece and its content will be a [`Document`](@Document)
+(which is a wrapper class for a list of strings or `ResourceReference`s). A Document has a one-to-one
+correspondence with an output file. Read more about it in the appropriate documentation section.
 END FILE DOCUMENTATION '''
 
 import pyjson5 as json

--- a/src/docthing/documentation_blob.py
+++ b/src/docthing/documentation_blob.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 2)
-TODO: documentation_blob documentation
-
 Everything in `docthing` is about the class [`DocumentationBlob`](@DocumentationBlob).
 
 This class is the one create after the _index file_ is processed accordingly to the _configuration_.
@@ -11,8 +9,26 @@ used to generate documentation in various formats.
 
 To export the documentation in a specific format, you can use an `Exporter Plugin` which is a
 class that implements the [`Exporter`](@Exporter) abstract class.
-After being correctly instantiated, a DocumentationBlob can be exported to a specific format passing
-it to the constructor of the `Exporter` implementation.
+After being correctly instantiated, a `DocumentationBlob` can be exported to a specific format passing
+it to the method `export` of an instance of a concrete `Exporter` implementation.
+
+Before exporting the documentation, it is possible to apply _Meta Interpreters_ plugins to the
+`DocumentationBlob` instance. These type of plugins are concrete implementations of the
+[`MetaInterpreter`](@MetaInterpreter) abstract class and tehy can be used to apply some specific
+modification to each node of the documentation tree based on some rules defined in the plugin itself.
+
+---
+
+`DocumentationBlob` is a tree structured object that contains the entire project documentation
+that honors the [`Tree`](@Tree) interface. A tree structure is perfect for representing
+the hierarchical structure of documentation, where each node can have multiple child nodes.
+
+Each node with child(ren) is a _Section_ and outermost children (children of the root node) are referred
+as _Chapters_ (which are just sections with a fancy name).
+
+Each leaf of the tree represents a documentation content.
+
+
 END FILE DOCUMENTATION '''
 
 import pyjson5 as json

--- a/src/docthing/documentation_content.py
+++ b/src/docthing/documentation_content.py
@@ -1,6 +1,18 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 2)
-TODO: documentation_content documentation
+A [`Document`](@Document) is a wrapper class for a list of strings or `ResourceReference`s.
+The strings represent actual text content, while `ResourceReference`s are used to
+represent references to external resources such as images, files, or other resources.
+
+When a [`DocumentationBlob`](@DocumentationBlob) is exported to a specific format,
+the `Document` objects are used to produce the output of a specific file. Strings are
+written to the output file directly, while `ResourceReference`s are compiled and written
+to the output file in the appropriate syntax depending on the selected [`Exporter`](@Exporter)
+plugin and the format of the output resource format.
+
+For example, if the `ResourceReference` is an image, and the `Exporter` plugin will export
+the documentation to LaTeX, the `ResourceReference` will be compiled to a LaTeX
+`\includegraphics` command.
 END FILE DOCUMENTATION '''
 
 import re

--- a/src/docthing/documentation_content.py
+++ b/src/docthing/documentation_content.py
@@ -12,7 +12,7 @@ plugin and the format of the output resource format.
 
 For example, if the `ResourceReference` is an image, and the `Exporter` plugin will export
 the documentation to LaTeX, the `ResourceReference` will be compiled to a LaTeX
-`\includegraphics` command.
+`\\includegraphics` command.
 END FILE DOCUMENTATION '''
 
 import re

--- a/src/docthing/documentation_content.py
+++ b/src/docthing/documentation_content.py
@@ -149,6 +149,7 @@ class Document():
         else:
             self.content = content
 
+    @staticmethod
     def can_be(vec):
         '''
         Returns whether the given vector can be a Document.
@@ -164,6 +165,9 @@ class Document():
         return True
 
     def get_printable(self) -> str:
+        """
+        Returns a printable version of the document.
+        """
         if isinstance(self.content, str):
             return self.content
         elif isinstance(self.content, ResourceReference):
@@ -202,6 +206,9 @@ class Document():
             [reference] + self.content[end + 1:]
 
     def replace_resources_with_imports(self, title, import_function):
+        """
+        Replaces all resource references with imports.
+        """
         for i, el in enumerate(self.content):
             if isinstance(
                     el,
@@ -209,6 +216,9 @@ class Document():
                 self.content[i] = import_function(title, el)
 
     def prepend_resource(self, resource):
+        """
+        Prepends a resource to the document.
+        """
         if isinstance(resource, list):
             for el in resource:
                 if not isinstance(el, (ResourceReference, str)):
@@ -224,6 +234,9 @@ class Document():
             self.content.insert(0, resource)
 
     def append_resource(self, resource):
+        """
+        Appends a resource to the document.
+        """
         if isinstance(resource, list):
             for el in resource:
                 if not isinstance(el, (ResourceReference, str)):

--- a/src/docthing/extractor.py
+++ b/src/docthing/extractor.py
@@ -1,7 +1,21 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 3)
-Other testing lines
-TODO: extractor documentation
+The `extract_documentation` method is responsible for extracting documentation
+from a given file path using a specified parser configuration.
+
+I would not call this much as a _parser_ but rather as a _stripper_ (LOL): this
+method performs some parsing but it is minimal. The way you can look at what it does
+is more like stripping the file from anything that is not documentation.
+
+The way it works is really simple:
+1. it reads the file line by line until it finds a line that starts with what was
+   specified in the configuration file as the `begin_ml_comment` followed by the
+   `begin_doc` part;
+2. continues reading the file until it finds a line that starts with what was
+   specified as the `end_ml_comment` preceeded by the `end_doc` part;
+3. returns the documentation block found;
+4. if the line found at point 1. contains options, it will parse them and
+   return them as a dict.
 END FILE DOCUMENTATION '''
 
 

--- a/src/docthing/plugins/exporter/markdown.py
+++ b/src/docthing/plugins/exporter/markdown.py
@@ -40,7 +40,7 @@ class MarkdownExporter(Exporter):
 
         # If the page does not start with a title insert it
         for line in output.split('\n'):
-            if not isinstance(line, str) and line.strip() != '':
+            if isinstance(line, str) and line.strip() != '':
                 if not line.startswith('# '):
                     output = '# ' + leaf.get_title() +\
                         '\n\n' + output

--- a/src/docthing/plugins/exporter_interface.py
+++ b/src/docthing/plugins/exporter_interface.py
@@ -1,6 +1,35 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 2)
-TODO: exporter_interface documentation
+The `Exporter` interface is used to create plugins that export
+documentation to a specific format.
+
+> Even if you are interested in developing a meta-interpreter,
+> I suggest you to read the documentation of [`Exporter`](@Exporter)
+> plugins too to have a better understanding of how the whole
+> process works.
+
+## Implement an exporter
+
+Exporters are really simple plugins to understand and, on the
+theoretical level, they are really simple but their implementation
+tends to be quite complicated.
+
+The interface is quite simple and all you need to do is to implement
+the following methods: `_export_leaf` and `import_function`.
+The first one is used to export a single leaf node of the documentation
+blob to the specified format and the second one is used to import an
+external resoruce into the ouput documentation. For example see the
+builtin `markdown` exporter: it implements different methods to create
+different _imports_ for different types of resources: when the resource
+is an image, it will replace the `ResourceReference` with the string
+`![...](...)`. In an hypothetical LaTeX exporter, the import would
+be something like `\\includegraphics{...}`.
+
+The complexity is really behind this behaviour because the developer
+should be able to define how to import a resource in any format.
+The common syntax will always look like `@ref(type)-->[path]` as you
+can see in the implementation of the method `__str__` in the
+`ResourceReference` class.
 END FILE DOCUMENTATION '''
 
 from abc import abstractmethod

--- a/src/docthing/plugins/manager.py
+++ b/src/docthing/plugins/manager.py
@@ -1,6 +1,25 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 2)
-TODO: manager documentation
+All the methods exposed by a Plugin implementing the `PluginInterface`
+should not be called manually. Instead, they should be called by the
+`PluginManager` class.
+
+A `PluginManager` is responsible for managing the lifecycle of plugins.
+It provides methods to enable and disable plugins, as well as to get a
+list of all the enabled plugins.
+
+The `PluginManager` class is intended to be instantiated one for each
+_plugin type_. For example, there are currently two types of plugins
+in `docthing` currently: [`ExporterPlugin`](@ExporterPlugin)s and
+[`MetaInterpreterPlugin`](@MetaInterpreterPlugin)s (which are provided
+as abstract classes for implementation).
+
+> Note: if you are planning to add a new plugin to `docthing` which
+> implements one of these two interfaces, you should not bother with
+> understanding deeply the way the `PluginManager` class works.
+
+Once all plugins are enabled, the `PluginManager` will be able to
+let the user iterate over all them to perform some action.
 END FILE DOCUMENTATION '''
 
 import os

--- a/src/docthing/plugins/meta_interpreter_interface.py
+++ b/src/docthing/plugins/meta_interpreter_interface.py
@@ -1,15 +1,55 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 2)
+`MetaInterpreter` is an abstract class that defines the interface for
+meta-interpreters plugins.
 
-TODO: meta_interpreter_interface documentation
+> Even if you are interested in developing a meta-interpreter,
+> I suggest you to read the documentation of [`Exporter`](@Exporter)
+> plugins too to have a better understanding of how the whole
+> process works.
 
-This comes from the `docthing/plugins/meta_interpreter.py` file.
+This kind of plugins are used to modify the documentation blob by
+intervening at the beginning of the file, at the end of the file or
+at the beginning of each _special block_ of the file.
 
-@startuml
-Bob -> Alice : hello
-@enduml
+## Beginning and ending of file modes
 
-In the documentation, the code block should have been replaced by a uuid.
+When a meta-interpreter is used in `begin_file` or `end_file` mode,
+it will be called once for each [`Document`](@Document) in the
+documentation blob to apply some changes to it at the beginning
+or at the end of the file respectively. A good example of this is
+the `nav.md` meta-interpreter that is used to generate the navigation
+links at the end of the page (`end_file` mode).
+
+## Block mode
+
+When a meta-interpreter is used in `block` mode, it will be look for
+a special line to start _capturing_ the content of the block until
+it finds a special line to stop capturing it. These special lines
+are defined by the user by implementing the `_get_begin_code` and
+`_get_end_code` methods. These methods should return a string or a
+regualr expression since they will be passed as argument in `re.search`
+used in `is_begin_code` and `is_end_code` methods respectively.
+Finally, once the block is captured, the `generate_resource` method
+will be called to generate a resource that will be added to the
+`Document` replacing the block with a reference to the resource
+in the form of a [`ResourceReference`](@ResourceReference). This kind
+of objects are later used by the [`Exporter`](@Exporter) plugin to
+generate the output file and the way it is built should be defined in the
+implementation of the method `generate_resource`. A good example of this
+is the builtin `plantuml` plugin that will look for `@startuml` and
+`@enduml` to capture the PlantUML code blocks and replace them with an
+implementation of `ResourceReference` called `PlantUMLReference`.
+
+As you might have guessed at this point, when you create a `MetaInterpreter`
+plugin, you should implement also a custom `ResourceReference` that will be
+used by `Exporter` plugins to generate the output file. In order ti do so
+the exporter will need to know if the resource need to be compiled (and
+enevtually how to do it) and what the output extension will be. The compilation
+process should be defined in the `compile` method of the `ResourceReference`
+implementation and the output extension should be defined in the `get_ext`
+method. The extension is later used by the exporter to determine the exact
+output file name.
 
 END FILE DOCUMENTATION '''
 

--- a/src/docthing/plugins/plugin_interface.py
+++ b/src/docthing/plugins/plugin_interface.py
@@ -1,6 +1,36 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 2)
-TODO: plugin_interface documentation
+The strength of `docthing` is its extensibility. This feature is achieved
+through the use of plugins.
+
+A plugin is a Python module that implements the `PluginInterface` interface.
+Plugins can be enabled and disabled using the `enable` and `disable` methods,
+respectively. These two methods will call the `_enable` and `_disable` methods,
+which are defined by the user implementing the `PluginInterface` interface.
+
+Every plugin should define a `name` attribute that is used to identify the plugin,
+and a `description` attribute that describes the plugin and its `dependencies`.
+This can be achieved by implementing the `get_name`, `get_description`, and
+`get_dependencies` abstract methods. Dependencies are defined as a list of
+strings that represent the names of the bianries expected to found in the system
+that are required by the plugin to work properly. If the plugin has no dependencies,
+the `get_dependencies` method should return an empty list.
+
+Plugins can also support configuration through a configuration file. If so it should
+define a `schema` method that returns a `Schema` object that is used to validate the
+configuration. While enabling the plugin, the [`PluginManager`](@PluginManager) will
+first `validate` the configuration using the provided `Schema` and then call the
+`configure` method.
+This method will call an `_configure` method that, in case the plugin needs additional
+configuration, should be overwritten.
+
+It is up to the user to implement a method to actually _apply_ some changes to the
+[`DocumentationBlob`](@DocumentationBlob) using the plugin. For instance, the
+[`Exporter`](@Exporter) abstract class (and therefore all its subclasses) implements
+the `export` method that takes a `DocumentationBlob` to export the documentation and
+the [`MetaInterpreter`](@MetaInterpreter) implements the `interpret` method which
+takes a `DocumentationBlob` to apply some changes to it, depending on the plugin
+implementation.
 END FILE DOCUMENTATION '''
 
 from abc import ABC, abstractmethod

--- a/src/docthing/plugins/plugin_interface.py
+++ b/src/docthing/plugins/plugin_interface.py
@@ -8,6 +8,8 @@ Plugins can be enabled and disabled using the `enable` and `disable` methods,
 respectively. These two methods will call the `_enable` and `_disable` methods,
 which are defined by the user implementing the `PluginInterface` interface.
 
+### Definition
+
 Every plugin should define a `name` attribute that is used to identify the plugin,
 and a `description` attribute that describes the plugin and its `dependencies`.
 This can be achieved by implementing the `get_name`, `get_description`, and
@@ -15,6 +17,8 @@ This can be achieved by implementing the `get_name`, `get_description`, and
 strings that represent the names of the bianries expected to found in the system
 that are required by the plugin to work properly. If the plugin has no dependencies,
 the `get_dependencies` method should return an empty list.
+
+### Tuning
 
 Plugins can also support configuration through a configuration file. If so it should
 define a `schema` method that returns a `Schema` object that is used to validate the
@@ -24,6 +28,8 @@ first `validate` the configuration using the provided `Schema` and then call the
 This method will call an `_configure` method that, in case the plugin needs additional
 configuration, should be overwritten.
 
+### Usage
+
 It is up to the user to implement a method to actually _apply_ some changes to the
 [`DocumentationBlob`](@DocumentationBlob) using the plugin. For instance, the
 [`Exporter`](@Exporter) abstract class (and therefore all its subclasses) implements
@@ -31,6 +37,16 @@ the `export` method that takes a `DocumentationBlob` to export the documentation
 the [`MetaInterpreter`](@MetaInterpreter) implements the `interpret` method which
 takes a `DocumentationBlob` to apply some changes to it, depending on the plugin
 implementation.
+
+### Create you plugin
+
+To create a plugin, you need to create a new Python module that implements the
+`PluginInterface` interface. The module should be placed in the `plugins`
+directory of the docthing application. The module should define a class that
+implements the `PluginInterface` interface directly if it is a Plugin of a _new type_
+optherwise it should inherit from the appropriate abstract class (chosing between
+[`MetaInterpreter`](@MetaInterpreter) and [`Exporter`](@Exporter), see related
+documentation).
 END FILE DOCUMENTATION '''
 
 from abc import ABC, abstractmethod

--- a/src/docthing/util.py
+++ b/src/docthing/util.py
@@ -1,6 +1,22 @@
 # SPDX-License-Identifier: MIT
 ''' BEGIN FILE DOCUMENTATION (level: 3)
-TODO: util documentation
+Useful development tools are provided inside the `docthing.util` module.
+This module contains function that are used by docthing internally and should
+**never** be used by users of docthing.
+These functions are not guaranteed to be stable and may change at any time.
+What is granted is that if the function signature changes, it will be
+documented in the changelog. If the function is deprecated, it will be
+marked as such. If the function is removed, it will be marked as deprecated
+for at least one major version.
+At this time the provided functions are:
+- `mkdir_silent(output_dir)`: creates the specified output directory if it
+doesn't already exist.
+- `sha256sum(string)`: computes the SHA-256 hash of a given string.
+- `get_datadir()`: returns a parent directory path where persistent application
+data can be stored.
+- `get_docthing_datadir()`: returns the path to the docthing data directory.
+- `get_docthing_plugin_dir(plugin_type)`: returns the path to the docthing
+plugin directory.
 END FILE DOCUMENTATION '''
 
 import os


### PR DESCRIPTION
This merge request closes #1.

## Changes

- Fix: the `markdown` exporter plugin was not automatically creating the title when not present in the in-file documentation
- Add: in-file documentation in all files that are referenced by the `docthing.jsonc`